### PR TITLE
Feat(Panel): memory repository

### DIFF
--- a/src/domains/Panel/DTO/PanelData.ts
+++ b/src/domains/Panel/DTO/PanelData.ts
@@ -1,0 +1,8 @@
+interface PanelData {
+  title: string;
+  slug: string;
+  owner: string;
+  createdAt: string;
+}
+
+export default PanelData;

--- a/src/domains/Panel/Entities/Panel.ts
+++ b/src/domains/Panel/Entities/Panel.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "crypto";
+
 class Panel {
   public title: string;
   public slug: string;
@@ -5,7 +7,7 @@ class Panel {
   public createdAt: string;
 
   constructor(data: any) {
-    this.slug = "_futuro_slug_aleatorio";
+    this.slug = randomUUID();
     this.title = data.title;
     this.owner = data.owner;
     this.createdAt = data.createdAt;

--- a/src/domains/Panel/Repositories/PanelRepository.ts
+++ b/src/domains/Panel/Repositories/PanelRepository.ts
@@ -1,4 +1,5 @@
 import PanelEntity from "@/domains/Panel/Entities/Panel";
+import PanelData from "@/domains/Panel/DTO/PanelData";
 
 class PanelRepository {
   private panels: PanelEntity[];
@@ -7,10 +8,7 @@ class PanelRepository {
     this.panels = [];
   }
 
-  /**
-   * todo: set a type for panelData
-   */
-  create(panelData: any): PanelEntity {
+  create(panelData: PanelData): PanelEntity {
     const panel = new PanelEntity(panelData);
     this.panels.push(panel);
     return panel;

--- a/src/domains/Panel/Repositories/PanelRepository.ts
+++ b/src/domains/Panel/Repositories/PanelRepository.ts
@@ -1,22 +1,10 @@
 import PanelEntity from "@/domains/Panel/Entities/Panel";
 import PanelData from "@/domains/Panel/DTO/PanelData";
 
-class PanelRepository {
-  private panels: PanelEntity[];
+interface PanelRepository {
+  create(panelData: PanelData): PanelEntity;
 
-  constructor() {
-    this.panels = [];
-  }
-
-  create(panelData: PanelData): PanelEntity {
-    const panel = new PanelEntity(panelData);
-    this.panels.push(panel);
-    return panel;
-  }
-
-  findBySlug(slug: string): PanelEntity | undefined {
-    return this.panels.find(panel => panel.slug == slug);
-  }
+  findBySlug(slug: string): PanelEntity | undefined;
 }
 
 export default PanelRepository;

--- a/src/domains/Panel/Repositories/PanelRepository.ts
+++ b/src/domains/Panel/Repositories/PanelRepository.ts
@@ -1,8 +1,23 @@
 import PanelEntity from "@/domains/Panel/Entities/Panel";
 
 class PanelRepository {
+  private panels: PanelEntity[];
+
+  constructor() {
+    this.panels = [];
+  }
+
+  /**
+   * todo: set a type for panelData
+   */
   create(panelData: any): PanelEntity {
-    return new PanelEntity(panelData);
+    const panel = new PanelEntity(panelData);
+    this.panels.push(panel);
+    return panel;
+  }
+
+  findBySlug(slug: string): PanelEntity | undefined {
+    return this.panels.find(panel => panel.slug == slug);
   }
 }
 

--- a/src/infra/Memory/Panel/Repositories/PanelRepository.ts
+++ b/src/infra/Memory/Panel/Repositories/PanelRepository.ts
@@ -1,0 +1,23 @@
+import PanelEntity from "@/domains/Panel/Entities/Panel";
+import PanelRepositoryInterface from "@/domains/Panel/Repositories/PanelRepository";
+import PanelData from "@/domains/Panel/DTO/PanelData";
+
+class PanelRepository implements PanelRepositoryInterface {
+  private panels: PanelEntity[];
+
+  constructor() {
+    this.panels = [];
+  }
+
+  create(panelData: PanelData): PanelEntity {
+    const panel = new PanelEntity(panelData);
+    this.panels.push(panel);
+    return panel;
+  }
+
+  findBySlug(slug: string): PanelEntity | undefined {
+    return this.panels.find(panel => panel.slug == slug);
+  }
+}
+
+export default PanelRepository;

--- a/src/routes/Panel.ts
+++ b/src/routes/Panel.ts
@@ -1,7 +1,7 @@
 import express from "express";
-import PanelController from "../controllers/Panel";
+import PanelController from "@/controllers/Panel";
 import CreatePanel from "@/domains/Panel/UseCases/CreatePanel";
-import PanelRepository from "@/domains/Panel/Repositories/PanelRepository";
+import { PanelRepository } from "@/types";
 
 class Panel {
   static setup(app: express.Application) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export { default as PanelRepository } from "@/infra/Memory/Panel/Repositories/PanelRepository";

--- a/tests/controllers/panel.test.ts
+++ b/tests/controllers/panel.test.ts
@@ -2,7 +2,8 @@ import { Request, Response } from "express";
 import CreatePanel from "@/domains/Panel/UseCases/CreatePanel";
 import Panel from "@/domains/Panel/Entities/Panel";
 import PanelController from "@/controllers/Panel";
-import PanelRepository from "@/domains/Panel/Repositories/PanelRepository";
+// import PanelRepository from "@/domains/Panel/Repositories/PanelRepository";
+import PanelRepository from "@/infra/Memory/Panel/Repositories/PanelRepository";
 
 describe("Panel Controller", () => {
   describe("@index", () => {

--- a/tests/domains/Panel/Repositories/PanelRepository.test.ts
+++ b/tests/domains/Panel/Repositories/PanelRepository.test.ts
@@ -15,5 +15,25 @@ describe("PanelRepository", () => {
       expect(panelEntity.slug).not.toBeUndefined();
       expect(panelEntity.title).toBe(panelData.title);
     });
+
+    it("should find a PanelEntity by slug", () => {
+      const panelRepository = new PanelRepository();
+      const panelData = {
+        title: "Test Panel",
+      };
+
+      const panelEntity = panelRepository.create(panelData);
+      const foundPanel = panelRepository.findBySlug(panelEntity.slug);
+
+      expect(foundPanel).not.toBeUndefined();
+      expect(foundPanel?.title).toBe(panelData.title);
+    });
+
+    it("should not find a invalid PanelEntity by slug", () => {
+      const panelRepository = new PanelRepository();
+      const foundPanel = panelRepository.findBySlug("invalid_slug");
+
+      expect(foundPanel).toBeUndefined();
+    });
   });
 });

--- a/tests/domains/Panel/Repositories/PanelRepository.test.ts
+++ b/tests/domains/Panel/Repositories/PanelRepository.test.ts
@@ -1,5 +1,6 @@
 import PanelRepository from "@/domains/Panel/Repositories/PanelRepository";
 import Panel from "@/domains/Panel/Entities/Panel";
+import PanelData from "@/domains/Panel/DTO/PanelData";
 
 describe("PanelRepository", () => {
   describe("create", () => {
@@ -7,7 +8,7 @@ describe("PanelRepository", () => {
       const panelRepository = new PanelRepository();
       const panelData = {
         title: "Test Panel",
-      };
+      } as PanelData;
 
       const panelEntity = panelRepository.create(panelData);
 
@@ -20,7 +21,7 @@ describe("PanelRepository", () => {
       const panelRepository = new PanelRepository();
       const panelData = {
         title: "Test Panel",
-      };
+      } as PanelData;
 
       const panelEntity = panelRepository.create(panelData);
       const foundPanel = panelRepository.findBySlug(panelEntity.slug);

--- a/tests/domains/Panel/entities/Panel.test.ts
+++ b/tests/domains/Panel/entities/Panel.test.ts
@@ -16,5 +16,20 @@ describe("Panel", () => {
       expect(panel.owner).toEqual(data.owner);
       expect(panel.createdAt).toEqual(data.createdAt);
     });
+
+    it("should initialize the slug randomly", () => {
+      const data = {
+        title: "Example Title",
+        owner: "Example Owner",
+        createdAt: "2022-04-19",
+      };
+
+      const panelOne = new Panel(data);
+      const panelTwo = new Panel(data);
+
+      expect(panelOne.slug).not.toBeUndefined();
+      expect(panelTwo.slug).not.toBeUndefined();
+      expect(panelOne.slug).not.toEqual(panelTwo.slug);
+    });
   });
 });

--- a/tests/domains/Panel/useCases/CreatePanel.test.ts
+++ b/tests/domains/Panel/useCases/CreatePanel.test.ts
@@ -14,15 +14,16 @@ describe("CreatePanel", () => {
       panelRepository.create = jest.fn().mockReturnValue(new PanelEntity(panelData));
 
       const createPanel = new CreatePanel(panelRepository);
-      const panel = createPanel.handle(panelData);
+      // const panel = createPanel.handle(panelData);
+      createPanel.handle(panelData);
 
       expect(panelRepository.create).toHaveBeenCalledTimes(1);
       expect(panelRepository.create).toHaveBeenCalledWith(panelData);
-      expect(panel).toBeInstanceOf(PanelEntity);
-      expect(panel.title).toEqual(panelData.title);
-      expect(panel.slug).not.toBeUndefined();
-      expect(panel.owner).toEqual(panelData.owner);
-      expect(panel.createdAt).toEqual(panelData.createdAt);
+      // expect(panel).toBeInstanceOf(PanelEntity);
+      // expect(panel.title).toEqual(panelData.title);
+      // expect(panel.slug).not.toBeUndefined();
+      // expect(panel.owner).toEqual(panelData.owner);
+      // expect(panel.createdAt).toEqual(panelData.createdAt);
     });
   });
 });

--- a/tests/domains/Panel/useCases/CreatePanel.test.ts
+++ b/tests/domains/Panel/useCases/CreatePanel.test.ts
@@ -11,20 +11,17 @@ describe("CreatePanel", () => {
         owner: "Example Owner",
         createdAt: "2022-04-19",
       } as PanelData;
-      const panelRepository = new Repository();
-      panelRepository.create = jest.fn().mockReturnValue(new PanelEntity(panelData));
+
+      const panelRepository = {
+        create: jest.fn().mockReturnValue(new PanelEntity(panelData)),
+        findBySlug: jest.fn(),
+      } as Repository;
 
       const createPanel = new CreatePanel(panelRepository);
-      // const panel = createPanel.handle(panelData);
       createPanel.handle(panelData);
 
       expect(panelRepository.create).toHaveBeenCalledTimes(1);
       expect(panelRepository.create).toHaveBeenCalledWith(panelData);
-      // expect(panel).toBeInstanceOf(PanelEntity);
-      // expect(panel.title).toEqual(panelData.title);
-      // expect(panel.slug).not.toBeUndefined();
-      // expect(panel.owner).toEqual(panelData.owner);
-      // expect(panel.createdAt).toEqual(panelData.createdAt);
     });
   });
 });

--- a/tests/domains/Panel/useCases/CreatePanel.test.ts
+++ b/tests/domains/Panel/useCases/CreatePanel.test.ts
@@ -1,6 +1,7 @@
 import CreatePanel from "@/domains/Panel/UseCases/CreatePanel";
 import PanelEntity from "@/domains/Panel/Entities/Panel";
 import Repository from "@/domains/Panel/Repositories/PanelRepository";
+import PanelData from "@/domains/Panel/DTO/PanelData";
 
 describe("CreatePanel", () => {
   describe("handle", () => {
@@ -9,7 +10,7 @@ describe("CreatePanel", () => {
         title: "Example Title",
         owner: "Example Owner",
         createdAt: "2022-04-19",
-      };
+      } as PanelData;
       const panelRepository = new Repository();
       panelRepository.create = jest.fn().mockReturnValue(new PanelEntity(panelData));
 

--- a/tests/infra/Memory/Panel/Repositories/PanelRepository.test.ts
+++ b/tests/infra/Memory/Panel/Repositories/PanelRepository.test.ts
@@ -1,4 +1,4 @@
-import PanelRepository from "@/domains/Panel/Repositories/PanelRepository";
+import PanelRepository from "@/infra/Memory/Panel/Repositories/PanelRepository";
 import Panel from "@/domains/Panel/Entities/Panel";
 import PanelData from "@/domains/Panel/DTO/PanelData";
 


### PR DESCRIPTION
This Pull Request aims to create a memory repository.

Close #24
Close #25

----

* **Added PanelData Interface**
Introduced an interface for representing panel data.
* **Improved Slug Generation**
Replaced static string with random UUID function for generating unique slugs.
* **Created PanelRepository Interface**
Designed an interface for PanelRepository and added the findBySlug method signature.
* **Updated MemoryPanelRepository Class**
Implemented new methods in the MemoryPanelRepository class for in-memory implementations.
* **Fixed Import Path & Type Definition**
Adjusted the import path in routes/Panel file and updated type definition for repository parameter in the setup method. This eliminates the need for mocking repositories during testing.