### PR TITLE
Chore/sanitize mongo types

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,8 +1,5 @@
 - MongoRepository
 
-- adicionar testes para PanelRepository do Mongo
-
-- chore: Retirar any de Collection no Mongo
 - chore: Fazer testes para Mongo
 
 - Listagem de Kudos

--- a/src/infra/MongoDB/Repositories/PanelRepository.ts
+++ b/src/infra/MongoDB/Repositories/PanelRepository.ts
@@ -43,7 +43,7 @@ class PanelRepository implements PanelRepositoryInterface {
   async update({ slug, panelData }: UpdateData): Promise<PanelEntity | null> {
     await this.db.connect();
     const collection = await this.db.getCollection<PanelModel>("panels");
-    const panelDocument = await collection.findFirst({ slug });
+    const panelDocument = await collection.findFirst({ slug } as PanelModel);
 
     if (!panelDocument?._id) {
       return null;
@@ -69,7 +69,7 @@ class PanelRepository implements PanelRepositoryInterface {
   async delete(slug: string): Promise<boolean> {
     await this.db.connect();
     const collection = await this.db.getCollection<PanelModel>("panels");
-    const panelDocument = await collection.findFirst({ slug });
+    const panelDocument = await collection.findFirst({ slug } as PanelModel);
 
     if (!panelDocument?._id) {
       return true;
@@ -81,7 +81,7 @@ class PanelRepository implements PanelRepositoryInterface {
   async archive(slug: string): Promise<boolean> {
     await this.db.connect();
     const collection = await this.db.getCollection<PanelModel>("panels");
-    const panelDocument = await collection.findFirst({ slug });
+    const panelDocument = await collection.findFirst({ slug } as PanelModel);
 
     if (!panelDocument?._id) {
       return false;
@@ -97,7 +97,7 @@ class PanelRepository implements PanelRepositoryInterface {
   async findBySlug(slug: string): Promise<PanelEntity | null> {
     await this.db.connect();
     const collection = await this.db.getCollection<PanelModel>("panels");
-    const panelDocument = await collection.findFirst({ slug });
+    const panelDocument = await collection.findFirst({ slug } as PanelModel);
 
     if (!panelDocument) {
       return null;
@@ -109,9 +109,11 @@ class PanelRepository implements PanelRepositoryInterface {
       owner: panelDocument.owner,
       createdAt: panelDocument.createdAt,
       updatedAt: panelDocument.updatedAt,
-      password: new PlainTextPassword(panelDocument.password),
+      password: BCryptPassword.fromHashedValue(panelDocument.password),
       status: panelDocument.status,
-      clientPassword: panelDocument.clientPassword ? new PlainTextPassword(panelDocument.clientPassword) : null,
+      clientPassword: panelDocument.clientPassword
+        ? BCryptPassword.fromHashedValue(panelDocument.clientPassword)
+        : null,
     });
   }
 }

--- a/src/infra/MongoDB/services/Collection.ts
+++ b/src/infra/MongoDB/services/Collection.ts
@@ -3,11 +3,11 @@ import { Collection as MongoCollection, OptionalId, Document, ObjectId } from "m
 export class Collection<T extends OptionalId<Document>> {
   constructor(private collection: MongoCollection) {}
 
-  async find(filter: any): Promise<T[]> {
+  async find(filter: T): Promise<T[]> {
     return (await this.collection.find(filter).toArray()) as T[];
   }
 
-  async findFirst(filter: any): Promise<T | null> {
+  async findFirst(filter: T): Promise<T | null> {
     const documents = await this.find(filter);
     return documents[0];
   }

--- a/src/infra/MongoDB/services/Collection.ts
+++ b/src/infra/MongoDB/services/Collection.ts
@@ -19,14 +19,7 @@ export class Collection<T extends OptionalId<Document>> {
   }
 
   async update(id: ObjectId, data: T): Promise<T> {
-    await this.collection.updateOne(
-      {
-        _id: id,
-      },
-      {
-        $set: data,
-      },
-    );
+    await this.collection.updateOne({ _id: id }, { $set: data });
 
     return data;
   }

--- a/src/infra/MongoDB/services/Database.ts
+++ b/src/infra/MongoDB/services/Database.ts
@@ -9,16 +9,17 @@ import { DatabaseInterface } from "./DatabaseInterface";
 export class Database implements DatabaseInterface {
   db: Db | null;
 
+  // TODO: inject Mongo Database
   constructor() {
     this.db = null;
   }
 
   async connect(): Promise<void> {
     dotEnvConfig();
-    const client = new MongoClient(process.env.DB_CONN_STRING || "");
+    const client = new MongoClient(String(process.env.DB_CONN_STRING));
     await client.connect();
     this.db = client.db(process.env.DB_NAME);
-    console.log("Connected successfully to database: " + process.env.DB_CONN_STRING);
+    // console.log("Connected successfully to database: " + process.env.DB_CONN_STRING);
   }
 
   async getCollection<T extends OptionalId<Document>>(collectionName: string): Promise<Collection<T>> {

--- a/src/infra/adapters/Express/routes/Panel.ts
+++ b/src/infra/adapters/Express/routes/Panel.ts
@@ -35,7 +35,7 @@ class Panel {
     app.put("/panel/archive/:slug", controller.archive());
     app.put("/panel/:slug", controller.update());
     app.delete("/panel/:slug", controller.delete());
-    app.get("/panel/:slug", controller.show());
+    app.post("/panel/:slug", controller.show());
   }
 }
 

--- a/tests/infra/MongoDB/services/Collection.test.ts
+++ b/tests/infra/MongoDB/services/Collection.test.ts
@@ -1,0 +1,96 @@
+import { Collection } from "@/infra/MongoDB/services/Collection";
+import { FindCursor, Collection as MongoCollection, ObjectId } from "mongodb";
+
+describe("Collection", () => {
+  let mongoCollectionMock: jest.Mocked<MongoCollection>;
+  let collection: Collection<any>;
+
+  beforeEach(() => {
+    mongoCollectionMock = {
+      find: jest.fn().mockImplementation(() => ({
+        toArray: jest.fn().mockResolvedValue([]),
+      })),
+      insertOne: jest.fn().mockResolvedValue({}),
+      updateOne: jest.fn().mockResolvedValue({}),
+      deleteOne: jest.fn().mockResolvedValue({ acknowledged: true }),
+    } as any;
+
+    collection = new Collection<any>(mongoCollectionMock);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("find", () => {
+    it("should find documents by filter", async () => {
+      const filter = { field: "value" };
+      const documents = [{ _id: new ObjectId().toHexString() }];
+
+      mongoCollectionMock.find.mockImplementationOnce(
+        () =>
+          ({
+            toArray: jest.fn().mockResolvedValueOnce(documents),
+          } as Partial<FindCursor<any>> as FindCursor<any>),
+      );
+
+      const result = await collection.find(filter);
+
+      expect(result).toEqual(documents);
+      expect(mongoCollectionMock.find).toHaveBeenCalledWith(filter);
+    });
+  });
+
+  describe("findFirst", () => {
+    it("should find first document by filter", async () => {
+      const filter = { field: "value" };
+      const document = { _id: new ObjectId().toHexString() };
+
+      mongoCollectionMock.find.mockImplementationOnce(
+        () =>
+          ({
+            toArray: jest.fn().mockResolvedValueOnce([document]),
+          } as Partial<FindCursor<any>> as FindCursor<any>),
+      );
+
+      const result = await collection.findFirst(filter);
+
+      expect(result).toEqual(document);
+      expect(mongoCollectionMock.find).toHaveBeenCalledWith(filter);
+    });
+  });
+
+  describe("insertOne", () => {
+    it("should insert one document", async () => {
+      const document = { field: "value" };
+
+      const result = await collection.insertOne(document);
+
+      expect(result).toEqual(document);
+      expect(mongoCollectionMock.insertOne).toHaveBeenCalledWith(document);
+    });
+  });
+
+  describe("update", () => {
+    it("should update one document", async () => {
+      const id = new ObjectId();
+      const document = { field: "newValue" };
+
+      const result = await collection.update(id, document);
+
+      expect(result).toEqual(document);
+      expect(mongoCollectionMock.updateOne).toHaveBeenCalledWith({ _id: id }, { $set: document });
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete one document", async () => {
+      const id = new ObjectId();
+
+      const result = await collection.delete(id);
+
+      expect(result).toEqual(true);
+      expect(mongoCollectionMock.deleteOne).toHaveBeenCalledWith({ _id: id });
+    });
+  });
+});

--- a/tests/infra/MongoDB/services/Database.test.ts
+++ b/tests/infra/MongoDB/services/Database.test.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata";
+import { MongoClient, Db, Collection as MongoCollection } from "mongodb";
+import { Collection } from "@/infra/MongoDB/services/Collection";
+import { Database } from "@/infra/MongoDB/services/Database";
+
+jest.mock("mongodb");
+jest.mock("dotenv");
+
+describe("Database", () => {
+  let mongoClientMock: jest.Mocked<MongoClient>;
+  let dbMock: jest.Mocked<Db>;
+
+  beforeEach(() => {
+    dbMock = {
+      collection: jest.fn(),
+    } as any;
+
+    mongoClientMock = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      db: jest.fn().mockReturnValue(dbMock),
+    } as any;
+
+    (MongoClient as unknown as jest.Mock).mockReturnValue(mongoClientMock);
+
+    process.env = {
+      DB_CONN_STRING: "mongodb://localhost:27017",
+      DB_NAME: "test",
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should connect to database", async () => {
+    const database = new Database();
+
+    await database.connect();
+
+    expect(mongoClientMock.connect).toBeCalled();
+    expect(mongoClientMock.db).toBeCalledWith(process.env.DB_NAME);
+    expect(database.db).toBe(dbMock);
+  });
+
+  it("should return a Collection instance", async () => {
+    const collectionName = "testCollection";
+
+    dbMock.collection.mockReturnValue({} as MongoCollection);
+
+    const database = new Database();
+    database.db = dbMock;
+
+    const collection = await database.getCollection(collectionName);
+
+    expect(collection).toBeInstanceOf(Collection);
+    expect(database.db?.collection).toBeCalledWith(collectionName);
+  });
+
+  it("should throw an error if database is not connected", async () => {
+    mongoClientMock.db = jest.fn().mockReturnValue(undefined);
+
+    const collectionName = "testCollection";
+
+    const database = new Database();
+
+    await expect(database.getCollection(collectionName)).rejects.toThrow(
+      "The connection with the database was not established.",
+    );
+  });
+});


### PR DESCRIPTION
* **Introduction of a New Test File**
A new test file, `Collection.test.ts`, has been added under the `tests/infra/MongoDB/services` directory, which aims to verify the correctness and reliability of the system's certain features.

* **Modification in Panel Web Route**
The `Panel.ts` file, located at `src/infra/adapters/Express/routes`, has been updated. The adjustment shifts the operation type for accessing `/panel/:slug` web route from GET (retrieve information) to POST (send data).

* **Refinement of Function Parameters**
The parameter specifications in two essential functions (`find` and `findFirst`) inside the `Collection.ts` file (at the `src/infra/MongoDB/services` path) have been improved by replacing 'any' with 'T', emphasizing a more specific type constraint, thus enhancing the reliability of the code.

* **Improvement in PanelRepository**
The function parameter for the `find` operation in the `PanelRepository.ts` file (found in `src/infra/MongoDB/Repositories`) has been updated. The shift from 'any' to 'PanelModel' provides more accuracy in data types and improves the stability of the function.

* **Clean Up in Database.ts File**
Redundant console log statement from the `Database.ts` file, situated in `src/infra/MongoDB/services`, has been removed to clean up the code and improve readability.

* **Addition of New Class Tests**
New tests have been added for two classes - `Collection` and `Database`. These are located in `tests/infra/MongoDB/services` directory, and they aim to ensure the integrity and correctness of these classes' functionalities.

Close #92