### PR TITLE
refact: move swagger docs config to a router class

### DIFF
--- a/src/infra/adapters/Express/app.ts
+++ b/src/infra/adapters/Express/app.ts
@@ -11,46 +11,11 @@ import express from "express";
 import PanelRouter from "@/infra/adapters/Express/routes/Panel";
 import KudosRouter from "@/infra/adapters/Express/routes/Kudos";
 import UserRouter from "@/infra/adapters/Express/routes/UserRouter";
-import swaggerUi from "swagger-ui-express";
-import swaggerJSDoc from "swagger-jsdoc";
-// import { UserRepositoryType } from "@/domain/User/Repositories/UserRepository";
-
-const swaggerOptions = {
-  definition: {
-    openapi: "3.0.0",
-    info: {
-      title: "Kudos Board",
-      version: "1.0.0",
-      description: "API Kudos Board",
-    },
-    servers: [
-      {
-        url: "/",
-        description: "Base URL",
-      },
-    ],
-    components: {
-      securitySchemes: {
-        bearerAuth: {
-          type: "http",
-          scheme: "bearer",
-          bearerFormat: "JWT",
-        },
-      },
-    },
-  },
-  apis: ["./src/infra/adapters/Express/routes/*.ts", "./src/infra/adapters/Express/routes/schemas/*.yaml"],
-};
-const swaggerDocs = swaggerJSDoc(swaggerOptions);
+import ApiDocsRouter from "@/infra/adapters/Express/routes/ApiDocsRouter";
 
 const app = express();
 
-app.use(express.json()).use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
-app.get("/docs.json", (req, res) => {
-  res.setHeader("Content-Type", "application/json");
-  res.send(JSON.stringify(swaggerDocs));
-});
-
+ApiDocsRouter.setup(app);
 PanelRouter.setup(app);
 KudosRouter.setup(app);
 UserRouter.setup(app, container);

--- a/src/infra/adapters/Express/routes/ApiDocsRouter.ts
+++ b/src/infra/adapters/Express/routes/ApiDocsRouter.ts
@@ -1,0 +1,41 @@
+import express from "express";
+import swaggerUi from "swagger-ui-express";
+import swaggerJSDoc from "swagger-jsdoc";
+
+export default class ApiDocsRouter {
+  static setup(app: express.Application): void {
+    const swaggerOptions = {
+      definition: {
+        openapi: "3.0.0",
+        info: {
+          title: "Kudos Board",
+          version: "1.0.0",
+          description: "API Kudos Board",
+        },
+        servers: [
+          {
+            url: "/",
+            description: "Base URL",
+          },
+        ],
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: "http",
+              scheme: "bearer",
+              bearerFormat: "JWT",
+            },
+          },
+        },
+      },
+      apis: ["./src/infra/adapters/Express/routes/*.ts", "./src/infra/adapters/Express/routes/schemas/*.yaml"],
+    };
+    const swaggerDocs = swaggerJSDoc(swaggerOptions);
+
+    app.use(express.json()).use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
+    app.get("/docs.json", (req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.send(JSON.stringify(swaggerDocs));
+    });
+  }
+}


### PR DESCRIPTION
* **Refactored API Documentation Setup**
The application has been improved by removing unnecessary details in the main app file (`app.ts`) and adding a new dedicated router (`ApiDocsRouter.ts`), essentially making the code cleaner and easier to manage. This eliminates clutter from the main app file and isolates the API Documentation setup into a single, specialized router file.

* **Added a Specific Router for API Docs** 
A new file `ApiDocsRouter.ts`, has been introduced that better manages and organizes the setup for API documentation. This file takes charge of setting up the API documentation route and endpoint which makes it easier to modify or troubleshoot issues related to API documentation in the future. This restructuring also improves the modularity of the code. 

* **Removal of unused code**
The removal of some code lines in the `app.ts` file makes it more streamlined. Deprecated lines of code for 'swaggerUi' and 'swaggerJSDoc' were removed, improving the aesthetics of the code as well as reducing redundancy. The unnecessary endpoint for `/docs.json` was also cleaned up, simplifying the overall structure of the application. 

* **Implementing Code Modularity and Clean-up**
The changes in this pull request foster better code management and a more readable structure, promoting effective teamwork in the long run by making it easier for developers to understand, modify and reuse the code.